### PR TITLE
Update go-cose dependency to latest

### DIFF
--- a/cca/kat.go
+++ b/cca/kat.go
@@ -40,8 +40,6 @@ func (o KAT) Validate() error {
 
 	if o.Cnf == nil {
 		return errors.New("cnf claim missing")
-	} else if err := o.Cnf.COSEKey.Validate(); err != nil {
-		return fmt.Errorf("COSE key validation failed: %w", err)
 	}
 
 	return nil

--- a/cca/kat_test.go
+++ b/cca/kat_test.go
@@ -118,7 +118,7 @@ func TestKAT_FromCBOR_fail_bad_cnf(t *testing.T) {
 	var actual KAT
 	err := actual.FromCBOR(tv)
 
-	expectedErr := `KAT decoding failed: EC2 curve must be P-256, P-384, or P-521; found "X25519"`
+	expectedErr := `KAT decoding failed: invalid key: curve not supported for the given key type`
 
 	assert.EqualError(t, err, expectedErr)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/veraison/ccatoken v1.1.0
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
-	github.com/veraison/go-cose v1.1.1-0.20230613195103-433d4c233485
+	github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7
 	github.com/veraison/swid v0.0.1-beta.6
 )
 
@@ -27,7 +27,6 @@ require (
 	github.com/veraison/psatoken v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVv
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2OaLtg/jLoIubSUTrgz6iZ58pJ4=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
-github.com/veraison/go-cose v1.1.1-0.20230613195103-433d4c233485 h1:DrmH7fx8abH1uhkNyUv0pjH8DVkfkD9BcRLbrHr9Buo=
-github.com/veraison/go-cose v1.1.1-0.20230613195103-433d4c233485/go.mod h1:XIgugULT1VrP3RsJabABJqSvdMpy40KaAAhWbspGZUU=
+github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7 h1:KcKzBthSrSZIUEWBjVvkuk/DE3PyYFbXZxhx5byGFtc=
+github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7/go.mod h1:t6V8WJzHm1PD5HNsuDjW3KLv577uWb6UTzbZGvdQHD8=
 github.com/veraison/psatoken v1.2.0 h1:PeHy6YUbhFE9Z9xaQBoAMpMWUEqSHrF2JgfcwMTmFIA=
 github.com/veraison/psatoken v1.2.0/go.mod h1:2tHLoYMOIS4V4mO8MJT4VstRtpO50FLmhoOR35FyIr4=
 github.com/veraison/swid v0.0.1-beta.6 h1:ysDyCOPwGyjiBnhAM+/kgTEcc/PWieIbUQJOjnSTK48=
@@ -175,8 +175,6 @@ golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
 golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
Update the go-cose version to latest in the dependencies.

- cose.Key.Validate() is gone -- validation now happens automatically on UnmarshalCBOR().
- key type/curve mismatch error message has changed.